### PR TITLE
Update parameter name in get_details.js

### DIFF
--- a/sms/get_details.js
+++ b/sms/get_details.js
@@ -5,7 +5,7 @@ var p = plivo.RestAPI({
 });
 
 var params = {
-    'record_id': '005bcdf3-b1b9-4487-b8d3-59efb41431ca', // Message UUID for which the details have to be retrieved
+    'message_uuid': '005bcdf3-b1b9-4487-b8d3-59efb41431ca', // Message UUID for which the details have to be retrieved
 };
 
 p.get_message(params, function (status, response) {


### PR DESCRIPTION
I was a bit stuck on this point. From what I can see from the source code it should be message_uuid in the latest version of the library:

plivo.prototype.get_message = function (params, callback) {
    var action = 'Message/' + params['message_uuid'] + '/';
    delete params.message_uuid;
    var method = 'GET';

    this.request(action, method, params, callback);
};